### PR TITLE
POD fix in Dumbbench.pm

### DIFF
--- a/lib/Dumbbench.pm
+++ b/lib/Dumbbench.pm
@@ -481,6 +481,8 @@ value and the MAD of the truncated distribution as a measure of variability.
 To get the uncertainty on the expectation value, we take C<MAD / sqrt($N)> where
 C<$N> is the number of remaining measurements.
 
+=back
+
 =head2 Conclusion
 
 I hope I could convince you that interpreting less sophisticated benchmarks


### PR DESCRIPTION
In the prod version of Dumbbench I get:

POD ERRORS
       Hey! The above document had some coding errors, which are explained
       below:

```
   Around line 484:
       You forgot a '=back' before '=head2'
```

So, I added a =back around line 484 :-) Cheers!
