### PR TITLE
add --simple for default float format

### DIFF
--- a/bin/dumbbench
+++ b/bin/dumbbench
@@ -32,6 +32,8 @@ Options:
  --no-dry-run      Disable subtraction of dry runs.
  --raw             Set raw output mode. Only the final count will be
                    printed to stdout.
+ --simple          Set simple output mode. Numbers will be printed in
+                   default float format instead of scientific notation.
  -s|--std          Use the standard deviation instead of the MAD as a
                    measure of variability.
  --code='code'     Benchmarks Perl code (can be specified multiple times
@@ -58,6 +60,7 @@ our $InitialTimings  = 20; # more or less arbitrary but can't be much smaller th
 our $DryRunCmd;
 our $MaxIter         = 1000;
 our $RawOutput       = 0;
+our $SimpleOutput    = 0;
 our $UseStdDeviation = 0;
 our $PlotTimings     = 0; # hidden option since virtually nobody has SOOT
 our $DataTable       = undef;
@@ -75,6 +78,7 @@ GetOptions(
   'i|initial=i'      => \$InitialTimings,
   'm|maxiter=i'      => \$MaxIter,
   'raw'              => \$RawOutput,
+  'simple'           => \$SimpleOutput,
   's|std'            => \$UseStdDeviation,
   'plot_timings'     => \$PlotTimings,
   't|table=s'        => \$DataTable,
@@ -178,7 +182,7 @@ SCOPE: {
 
 }
 
-$bench->report($RawOutput);
+$bench->report($RawOutput, $SimpleOutput);
 
 if ($PlotTimings) {
   my @src = (

--- a/lib/Dumbbench.pm
+++ b/lib/Dumbbench.pm
@@ -240,9 +240,11 @@ sub _run {
 sub report {
   my $self = shift;
   my $raw = shift;
+  my $simple = shift;
   foreach my $instance ($self->instances) {
     my $result = $instance->result;
-    
+    my $result_str = ($simple) ? unscientific_notation($result) : "$result";
+
     if (not $raw) {
       my $mean = $result->raw_number;
       my $sigma = $result->raw_error->[0];
@@ -256,7 +258,7 @@ sub report {
       printf(
         "%sRounded run time per iteration: %s (%.1f%%)\n",
         $name,
-        "$result",
+        $result_str,
         $sigma/$mean*100
       );
       if ($self->verbosity) {
@@ -264,7 +266,7 @@ sub report {
       }
     }
     else {
-      print $result, "\n";
+      print $result_str, "\n";
     }
   }
 }
@@ -275,6 +277,10 @@ sub box_plot {
   return() if $@;
 
   return Dumbbench::BoxPlot->new($self);
+}
+
+sub unscientific_notation {
+  sprintf( "%f %s %f", split( / /, $_[0] ) );
 }
 
 1;


### PR DESCRIPTION
When results between rounded run times differ by an order of magnitude
or more, the default scientific notation can make it difficult to get
an at-a-glance sense of the results.
